### PR TITLE
add functionality for macOS High Sierra

### DIFF
--- a/reissue_filevault_recovery_key.sh
+++ b/reissue_filevault_recovery_key.sh
@@ -204,8 +204,10 @@ USER_PASS=${USER_PASS//\'/&apos;}
 
 # For 10.13's escrow process, store the last modification time of /var/db/FileVaultPRK.dat
 if [[ "$OS_MINOR" -ge 13 ]]; then
+    echo "Checking for /var/db/FileVaultPRK.dat on macOS 10.13+..."
     PRK_MOD=0
     if [ -e /var/db/FileVaultPRK.dat ]; then
+        echo "Found existing personal recovery key."
         PRK_MOD=$(stat -f "%Sm" -t "%s" /var/db/FileVaultPRK.dat)
     fi
 fi
@@ -238,6 +240,9 @@ if [[ "$OS_MINOR" -ge 13 ]]; then
         NEW_PRK_MOD=$(stat -f "%Sm" -t "%s" /var/db/FileVaultPRK.dat)
         if [[ $NEW_PRK_MOD -gt $PRK_MOD ]]; then
             ESCROW_STATUS=0
+            echo "Recovery key updated locally and available for collection via MDM."
+        else
+            echo "The recovery key does not appear to have been updated locally."
         fi
     fi
 else

--- a/reissue_filevault_recovery_key.sh
+++ b/reissue_filevault_recovery_key.sh
@@ -127,7 +127,7 @@ elif ! grep -q "FileVault is On" <<< "$FV_STATUS"; then
 fi
 
 # Get the logged in user's name
-CURRENT_USER="$(stat -f%Su /dev/console)"
+CURRENT_USER=$(python -c 'from SystemConfiguration import SCDynamicStoreCopyConsoleUser; import sys; username = (SCDynamicStoreCopyConsoleUser(None, None, None) or [None])[0]; username = [username,""][username in [u"loginwindow", None, u""]]; sys.stdout.write(username + "\n");')
 
 # This first user check sees if the logged in account is already authorized with FileVault 2
 FV_USERS="$(fdesetup list)"


### PR DESCRIPTION
This PR adds support for macOS High Sierra's new FileVault personal recovery key escrow functionality.

We check for the existence of `/var/db/FileVaultPRK.dat`, which is an encrypted file containing the personal recovery key for the device. The device's MDM is responsible for collecting and decrypting the file, which is not covered within the scope of this workflow. We cannot provide assurance this has taken place, so our best bet is to determine if the file has been modified after we attempt to rotate the recovery key. An updated modification time (or creation of the file if not previously existent) provides reasonable assurance the process worked correctly. Communication of the key back to the Jamf Pro Server is the responsibility of Jamf's MDMmonitor sending a successful `SecurityInfo` command.

"Recovery Key Redirection" functionality is still intact for 10.9–10.12, so this script does not break on "older" operating systems.

Additionally, this PR updates the collection of the current console user's username to the "Apple approved" method.