### PR TITLE
Bail out if running on macOS Catalina

### DIFF
--- a/reissue_filevault_recovery_key.sh
+++ b/reissue_filevault_recovery_key.sh
@@ -101,8 +101,9 @@ OS_MINOR=$(/usr/bin/sw_vers -productVersion | awk -F . '{print $2}')
 if [[ "$OS_MAJOR" -ne 10 || "$OS_MINOR" -lt 9 ]]; then
     REASON="This script requires macOS 10.9 or higher. This Mac has $(sw_vers -productVersion)."
     BAILOUT=true
-elif [[ "$OS_MAJOR" -eq 10 && "$OS_MINOR" -ge 13 ]]; then
-    echo "[WARNING] This script is still in BETA in High Sierra, because the fdesetup binary has changed significantly. Please use with caution."
+elif [[ "$OS_MAJOR" -eq 10 && "$OS_MINOR" -ge 15 ]]; then
+    echo "[ERROR] This script is unsupported on macOS Catalina, because user authentication information can no longer be passed to the fdesetup tool."
+    BAILOUT=true
 fi
 
 # Check to see if the encryption process is complete

--- a/reissue_filevault_recovery_key.sh
+++ b/reissue_filevault_recovery_key.sh
@@ -120,7 +120,7 @@ elif ! grep -q "FileVault is On" <<< "$FV_STATUS"; then
 fi
 
 # Get the logged in user's name
-CURRENT_USER=$(/usr/bin/python -c 'from SystemConfiguration import SCDynamicStoreCopyConsoleUser; import sys; username = (SCDynamicStoreCopyConsoleUser(None, None, None) or [None])[0]; username = [username,""][username in [u"loginwindow", None, u""]]; sys.stdout.write(username + "\n");')
+CURRENT_USER=$(/usr/bin/python -c 'from SystemConfiguration import SCDynamicStoreCopyConsoleUser; import sys; username = (SCDynamicStoreCopyConsoleUser(None, None, None) or [None])[0]; username = [username,""][username in [u"loginwindow", None, u""]]; sys.stdout.write(username);')
 
 # Make sure there's an actual user logged in
 if [[ -z $CURRENT_USER || "$CURRENT_USER" == "root" ]]; then


### PR DESCRIPTION
This script is unsupported on macOS Catalina, because user authentication information can no longer be passed to the `fdesetup` tool.