### PR TITLE
made CURRENT_USER definition not call Python

### DIFF
--- a/reissue_filevault_recovery_key.sh
+++ b/reissue_filevault_recovery_key.sh
@@ -111,7 +111,7 @@ elif ! grep -q "FileVault is On" <<< "$FV_STATUS"; then
 fi
 
 # Get the logged in user's name
-CURRENT_USER=$(/usr/bin/stat -f%Su "/dev/console")
+CURRENT_USER=$(/bin/echo "show State:/Users/ConsoleUser" | /usr/sbin/scutil | /usr/bin/awk '/Name :/&&!/loginwindow/{print $3}')
 
 # Make sure there's an actual user logged in
 if [[ -z $CURRENT_USER || "$CURRENT_USER" == "root" ]]; then

--- a/reissue_filevault_recovery_key.sh
+++ b/reissue_filevault_recovery_key.sh
@@ -11,8 +11,8 @@
 #                   be deployed in order for this script to work correctly.
 #          Author:  Elliot Jordan <elliot@elliotjordan.com>
 #         Created:  2015-01-05
-#   Last Modified:  2019-12-02
-#         Version:  1.9.4
+#   Last Modified:  2020-07-06
+#         Version:  1.9.5
 #
 ###
 
@@ -111,7 +111,7 @@ elif ! grep -q "FileVault is On" <<< "$FV_STATUS"; then
 fi
 
 # Get the logged in user's name
-CURRENT_USER=$(/usr/bin/python -c 'from SystemConfiguration import SCDynamicStoreCopyConsoleUser; import sys; username = (SCDynamicStoreCopyConsoleUser(None, None, None) or [None])[0]; username = [username,""][username in [u"loginwindow", None, u""]]; sys.stdout.write(username);')
+CURRENT_USER=$(/usr/bin/stat -f%Su "/dev/console")
 
 # Make sure there's an actual user logged in
 if [[ -z $CURRENT_USER || "$CURRENT_USER" == "root" ]]; then


### PR DESCRIPTION
- made `CURRENT_USER` definition not call Python (removes Python dependency to future-proof against Python runtime's eventual removal from macOS as per [macOS Catalina 10.15 Release Notes](https://developer.apple.com/documentation/macos-release-notes/macos-catalina-10_15-release-notes)) #31 